### PR TITLE
[Feat/#59] 사이드바 UX 개선 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ dist-ssr
 storybook-static
 
 .env
+
+# AI agent context files (local only)
+AGENTS.md
+**/AGENTS.md
+.claude/
+.cursor/

--- a/src/shared/layouts/header-lnb.tsx
+++ b/src/shared/layouts/header-lnb.tsx
@@ -39,11 +39,11 @@ const HeaderLnb = ({ openSidebar, closeSidebar, navigationDisabled = false }: He
   };
 
   const handleClick = (path: string) => {
-    const viewTabActive = pathname.startsWith('/receipts-list');
     const mgmtTabActive = pathname.startsWith('/management');
 
     if (navigationDisabled) {
       if (path === '/receipts-list') {
+        if (isSidebarOpen) closeSidebar?.();
         return;
       }
       if (path === '/management' && isAdmin) {
@@ -58,9 +58,8 @@ const HeaderLnb = ({ openSidebar, closeSidebar, navigationDisabled = false }: He
     }
 
     if (path === '/receipts-list') {
-      if (isSidebarOpen && viewTabActive) {
+      if (isSidebarOpen) {
         closeSidebar?.();
-
         return;
       }
       // 관리자는 학생회 관리 화면(/management)에 있을 때 조회만 누르면 URL이 그대로라

--- a/src/shared/layouts/root-layout.tsx
+++ b/src/shared/layouts/root-layout.tsx
@@ -2,6 +2,7 @@ import { isMaintenanceMode, maintenanceCopy } from '@constants/maintenance';
 import Footer from '@layouts/footer';
 import HeaderGnb from '@layouts/header-gnb';
 import Sidebar from '@layouts/sidebar';
+import { cn } from '@libs/cn';
 import Maintenance from '@pages/common/maintenance';
 import { AuthTokenWatcher } from '@routes/auth-token-watcher';
 import { useLayoutStore } from '@store/layout-store';
@@ -22,20 +23,26 @@ const RootLayout = () => {
         navigationDisabled={navigationDisabled}
       />
       <div className="relative flex flex-1">
-        {isSidebarOpen && (
-          <div className="absolute z-50 h-full md:static">
-            <Sidebar navigationDisabled={navigationDisabled} />
-          </div>
-        )}
-        <main className="relative min-h-0 flex-1 overflow-auto">
-          {isSidebarOpen && (
-            <button
-              type="button"
-              className="absolute inset-0 z-40 bg-black/20 max-md:block md:hidden"
-              onClick={closeSidebar}
-              aria-label="사이드바 닫기"
-            />
+        <div
+          className={cn(
+            'absolute z-50 h-full overflow-hidden transition-[width] duration-300 ease-in-out md:static',
+            isSidebarOpen ? 'w-[25.2rem]' : 'w-0',
           )}
+          aria-hidden={!isSidebarOpen}
+        >
+          <Sidebar navigationDisabled={navigationDisabled} />
+        </div>
+        <main className="relative min-h-0 flex-1 overflow-auto">
+          <button
+            type="button"
+            className={cn(
+              'absolute inset-0 z-40 bg-black/20 transition-opacity duration-300 max-md:block md:hidden',
+              isSidebarOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+            )}
+            onClick={closeSidebar}
+            aria-label="사이드바 닫기"
+            aria-hidden={!isSidebarOpen}
+          />
           {isMaintenanceMode ? <Maintenance maintenance={maintenanceCopy} /> : <Outlet />}
         </main>
       </div>

--- a/src/shared/layouts/sidebar.tsx
+++ b/src/shared/layouts/sidebar.tsx
@@ -90,35 +90,45 @@ const Sidebar = ({ navigationDisabled = false }: SidebarProps) => {
               onClick={() =>
                 setIsActiveCollege((prev) => (prev === item.collegeName ? '' : item.collegeName))
               }
+              aria-expanded={!setActiveSideBar(isActiveCollege, item.collegeName)}
               className="flex w-full cursor-pointer items-center justify-between py-[1.2rem] pr-[2.4rem] pl-[4rem]"
             >
               <p className="W_SB14 text-gray-90">{item.collegeName}</p>
               {setActiveSideBar(isActiveCollege, item.collegeName) ? (
-                <ArrowDownIcon className="text-gray-20" />
+                <ArrowDownIcon className="text-gray-20 transition-transform duration-300" />
               ) : (
-                <ArrowUpIcon className="text-gray-20" />
+                <ArrowUpIcon className="text-gray-20 transition-transform duration-300" />
               )}
             </button>
-            {!setActiveSideBar(isActiveCollege, item.collegeName) && (
-              <div className="w-full">
-                {item?.clubs?.map((club: college) => (
-                  <button
-                    key={club.studentClubId}
-                    type="button"
-                    onClick={() => handleMenuClick(club)}
-                    className={cn(
-                      'W_SB13 w-full cursor-pointer py-[1.4rem] pl-[4rem] text-start text-gray-90',
-                      (activeClubIdFromPath
-                        ? activeClubIdFromPath === String(club.studentClubId)
-                        : !setActiveSideBar(isActiveClubs, club.studentClubName)) &&
-                        'bg-background',
-                    )}
-                  >
-                    {club?.studentClubName}
-                  </button>
-                ))}
+            <div
+              className={cn(
+                'grid transition-[grid-template-rows] duration-300 ease-in-out',
+                setActiveSideBar(isActiveCollege, item.collegeName)
+                  ? 'grid-rows-[0fr]'
+                  : 'grid-rows-[1fr]',
+              )}
+            >
+              <div className="overflow-hidden">
+                <div className="w-full">
+                  {item?.clubs?.map((club: college) => (
+                    <button
+                      key={club.studentClubId}
+                      type="button"
+                      onClick={() => handleMenuClick(club)}
+                      className={cn(
+                        'W_SB13 w-full cursor-pointer py-[1.4rem] pl-[4rem] text-start text-gray-90',
+                        (activeClubIdFromPath
+                          ? activeClubIdFromPath === String(club.studentClubId)
+                          : !setActiveSideBar(isActiveClubs, club.studentClubName)) &&
+                          'bg-background',
+                      )}
+                    >
+                      {club?.studentClubName}
+                    </button>
+                  ))}
+                </div>
               </div>
-            )}
+            </div>
           </div>
         ))}
       </div>

--- a/src/shared/layouts/sidebar.tsx
+++ b/src/shared/layouts/sidebar.tsx
@@ -31,8 +31,7 @@ const Sidebar = ({ navigationDisabled = false }: SidebarProps) => {
   };
 
   const activeClubIdFromPath =
-    pathname.match(/^\/receipts-list\/(\d+)/)?.[1] ??
-    pathname.match(/^\/management\/(\d+)/)?.[1];
+    pathname.match(/^\/receipts-list\/(\d+)/)?.[1] ?? pathname.match(/^\/management\/(\d+)/)?.[1];
 
   useEffect(() => {
     const isClubMenuPage =
@@ -44,14 +43,14 @@ const Sidebar = ({ navigationDisabled = false }: SidebarProps) => {
   }, [pathname]);
 
   const handleMenuClick = (club: college) => {
-    const isSameActiveMenu = activeClubIdFromPath === String(club.studentClubId);
+    // const isSameActiveMenu = activeClubIdFromPath === String(club.studentClubId);
 
-    // 이미 활성화된 메뉴를 다시 누르면 메인으로 이동하면서 사이드바를 닫습니다.
-    if (isSameActiveMenu) {
-      navigate('/');
-      closeSidebar();
-      return;
-    }
+    // // 이미 활성화된 메뉴를 다시 누르면 메인으로 이동하면서 사이드바를 닫습니다.
+    // if (isSameActiveMenu) {
+    //   navigate('/');
+    //   closeSidebar();
+    //   return;
+    // }
 
     setIsActiveClubs(club?.studentClubName);
 
@@ -88,7 +87,9 @@ const Sidebar = ({ navigationDisabled = false }: SidebarProps) => {
           >
             <button
               type="button"
-              onClick={() => setIsActiveCollege(item.collegeName)}
+              onClick={() =>
+                setIsActiveCollege((prev) => (prev === item.collegeName ? '' : item.collegeName))
+              }
               className="flex w-full cursor-pointer items-center justify-between py-[1.2rem] pr-[2.4rem] pl-[4rem]"
             >
               <p className="W_SB14 text-gray-90">{item.collegeName}</p>


### PR DESCRIPTION
## 📌 변경 사항 요약
<!-- 이 PR에서 무엇을 변경했는지 간단히 적어 주세요 -->
- 사이드바 UX를 개선했다
상위 대학 클릭 시 아코디언으로 하위 목록이 나오지만 한번 더 눌렀을 때 하위 목록이 닫히지 않았다.
이번 PR에서는 상위 대학 클릭 시 하위 목록이 닫히도록 수정했다.

header-lnb에서 조회 클릭 시 사이드바가 닫히지 않았다.
이번 PR에서 조회를 클릭 시 사이드바가 닫히게 수정하였다.

추가로 애니메이션을 도입해 부드럽게 사이드바가 열리고 아코디언이 열리도록 수정하였다.

## 🔗 관련 이슈
<!-- 연결된 이슈가 있다면 "Closes #이슈번호" 형식으로 -->
Closes #59 

## 변경 유형
- [ ] 🐛 버그 수정
- [ ] ✨ 새 기능
- [x] 💄 UI/스타일 변경
- [ ] ♻️ 리팩터링
- [ ] 📝 문서 수정
- [ ] 🔧 설정/빌드 변경
- [ ] 기타 (설명):

## 체크리스트
- [ ] 로컬에서 동작 확인함
- [ ] `npm run lint` 통과
- [ ] `npm run build` 통과
- [ ] 필요 시 스토리북/스크린샷 추가

## 스크린샷 (UI 변경 시)
<!-- before/after 또는 변경된 화면 캡처 -->

## 추가 메모
<!-- 리뷰어가 알면 좋을 내용 -->

https://github.com/user-attachments/assets/54e8f297-018b-496b-a057-9a3deb9b9f5b


